### PR TITLE
retrieve and encode URL contents

### DIFF
--- a/app/controllers/tweet_controller.rb
+++ b/app/controllers/tweet_controller.rb
@@ -1,9 +1,23 @@
+require 'nokogiri'
+require 'pp'
+require 'open-uri'
+require 'uri'
+
 class TweetController < ApplicationController
   def new
   end
 
   def create
     @url = params[:url]
-    redirect_to("https://twitter.com/intent/tweet?text=#{@url}")
+    urlhtml = Nokogiri::HTML(open(@url))
+
+    # issueのタイトルを取得しツイート内容に表示
+    urlhtml.xpath("//h1[@class='gh-header-title f1 mr-0 flex-auto break-word']").each do |elements|
+      @text = (elements.xpath('.//span').text).gsub(/\r\n|\r|\n|\s|\t/, "")
+    end
+    query = URI.encode(@text + " " + "#Glitter")
+    @search_url = query
+
+    redirect_to("https://twitter.com/intent/tweet?text=#{@search_url}")
   end
 end


### PR DESCRIPTION
フォームにissueのURLを入力したら、issueのタイトルをエンコードしてツイート内容に表示できるようになりました。

### URL入力画面
![スクリーンショット 2020-02-11 15 00 00](https://user-images.githubusercontent.com/51523853/74214077-435fef00-4cdf-11ea-9a96-cc7bb563ca71.png)
### 投稿画面
![image](https://user-images.githubusercontent.com/51523853/74214103-64284480-4cdf-11ea-9c61-3b5b361a1bb3.png)
