### PR TITLE
fix routing error

### DIFF
--- a/app/controllers/tweet_controller.rb
+++ b/app/controllers/tweet_controller.rb
@@ -21,7 +21,7 @@ class TweetController < ApplicationController
   end
 
   def create
-    @url = "https://github.com/" + params[:url]
+    @url = "https://github.com/" + params[:url].strip
 
     # TODO: ユーザにダイアログ表示
     return until URI.regexp.match(@url) && working_url?(@url)
@@ -61,17 +61,17 @@ class TweetController < ApplicationController
 
   private
     def working_url?(url_str)
-      return open(@url).status.last == "OK"
+      return open(url_str).status.last == "OK"
     rescue
       false
     end
 
     def set_tweet
-      @tweet = Tweet.find(params[:id])
+      @tweet = Tweet.where(id: params[:id])&.first
     end
 
     def set_your_tweet
-      @your_tweet = Tweet.find(params[:id])
+      @your_tweet = Tweet.where(id: params[:id])&.first
     end
 
     def make_picture(id)

--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -1,4 +1,6 @@
 class Tweet < ApplicationRecord
+  validates :repository_url, length: { maximum: 50 }
+  validates :image_url, length: { maximum: 100 }
   after_initialize :set_default, if: :new_record?
 
   private


### PR DESCRIPTION
### tweetボタンが押せなかった理由
- URL入力欄の一文字目が空白が入っていて、存在しないURLになっていた。
→URL入力欄の空白をトリミング
- バリデーションの文字数が少なすぎたので、最大文字数を大きくした。

### エラーの理由
tweet/showを表示するときのidのパラメータにcreateが入ってしまっていた。
→DBのidでない場合は、nilを返してエラー回避した。